### PR TITLE
Fix debugger layout on Windows

### DIFF
--- a/GUI/Debugger/DebugFrame.cpp
+++ b/GUI/Debugger/DebugFrame.cpp
@@ -36,7 +36,7 @@ void DisasmFrame::InitWidgets()
 	hbox->Add(regPanel, wxSizerFlags(2).Expand().Border(wxALL, 10));
 
 	vbox->Add(hbox, wxSizerFlags(1).Expand());
-	SetSizer(vbox);
+	SetSizerAndFit(vbox);
 	//TODO: Use default color theme for windows?
 #ifndef __WXGTK__
 	SetBackgroundColour(*wxWHITE);

--- a/GUI/Debugger/DisasmPanel.cpp
+++ b/GUI/Debugger/DisasmPanel.cpp
@@ -11,7 +11,7 @@ DisasmPanel::DisasmPanel(std::shared_ptr<Debugger> d, wxWindow* parent)
 	wxBoxSizer* vbox = new wxBoxSizer(wxVERTICAL);
 
 	disasmList = new DisasmList(debugger, this);
-	vbox->Add(disasmList, wxSizerFlags(3).Expand());
+	vbox->Add(disasmList, wxSizerFlags(2).Expand());
 
 	// Puts disassembler controls in a tabbed interface
 	notebook = new wxNotebook(this, wxID_ANY);

--- a/GUI/Debugger/MemoryBrowser.cpp
+++ b/GUI/Debugger/MemoryBrowser.cpp
@@ -26,14 +26,22 @@ MemoryBrowser::MemoryBrowser(std::shared_ptr<Bus> b, wxWindow* parent)
     InsertColumn(static_cast<long>(ColumnID::CategoryAddress), itemCol);
     // Values
     itemCol.SetId(wxID_ANY);
-    itemCol.SetWidth(340);
+    itemCol.SetWidth(345);
     InsertColumn(static_cast<long>(ColumnID::Values), itemCol);
     // Ascii
     itemCol.SetId(wxID_ANY);
+#ifdef __WINDOWS__
+    itemCol.SetWidth(135);
+#elif __WXGTK__
     itemCol.SetWidth(125);
+#endif
     InsertColumn(static_cast<long>(ColumnID::Ascii), itemCol);
 
-    SetMinSize(wxSize(75+340+125, 100));
+#ifdef __WINDOWS__
+    SetMinSize(wxSize(75+345+135+20, 150));
+#elif __WXGTK__
+    SetMinSize(wxSize(75+340+125, 150));
+#endif
 
     RefreshValues();
 }


### PR DESCRIPTION
wxListView works differently in Windows and Linux. In Windows the control matches the size of the sizer. In Linux the extra space is filled with the background color.